### PR TITLE
Added single PDF end-to-end: ingest, query, streamed answer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Multi Doc Query is a local multi-document RAG chatbot using Chainlit as the UI and Ollama for LLM/embedding inference. It supports PDF and DOCX ingestion, hybrid retrieval (BM25 + semantic via ChromaDB), reciprocal rank fusion, and cross-encoder reranking.
+
+## Commands
+
+```bash
+# Install dependencies (uses uv)
+uv sync --dev
+
+# Run all tests
+uv run python -m pytest -v
+
+# Run a single test file
+uv run python -m pytest tests/test_config.py -v
+
+# Run the Chainlit app
+uv run chainlit run app.py
+
+# Prerequisites: Ollama must be running (`ollama serve`) with required models pulled
+ollama pull llama3.1:8b
+ollama pull mxbai-embed-large
+```
+
+## Architecture
+
+The app entry point is `app.py` (Chainlit hooks). Source code lives in `src/` with three pipeline stages as subpackages:
+
+- **`src/ingestion/`** - Document loading (PDF, DOCX), chunking via LangChain text splitters
+- **`src/retrieval/`** - Hybrid search: BM25 (rank-bm25) + semantic (ChromaDB + sentence-transformers), fused with RRF, then reranked (cross-encoder)
+- **`src/generation/`** - LLM response generation via Ollama
+
+Supporting modules:
+- **`src/config.py`** - Pydantic-validated config loaded from `config.yaml` (models, chunking params, retrieval params, paths)
+- **`src/health_check.py`** - Async Ollama connectivity and model availability checks (httpx)
+
+## Key Details
+
+- **Python 3.11+**, managed with **uv** (not pip)
+- Config in `config.yaml` at project root; validated by Pydantic models in `src/config.py`
+- Tests use **pytest** with **pytest-asyncio** (`asyncio_mode = "auto"` in pyproject.toml)
+- CI runs via GitHub Actions (`.github/workflows/ci.yml`) on push/PR to main
+- All inference is local via Ollama -- no cloud API keys needed
+- ChromaDB data stored at `~/.multi_doc_query/chroma_db/` by default

--- a/app.py
+++ b/app.py
@@ -1,7 +1,15 @@
+from pathlib import Path
+
 import chainlit as cl
+import chromadb
 
 from src.config import ConfigError, load_config
+from src.generation.answerer import answer
 from src.health_check import check_models, check_ollama
+from src.ingestion.chunker import chunk_documents
+from src.ingestion.loader import load_folder
+from src.retrieval.embeddings import make_ollama_embed_fn
+from src.retrieval.vector_store import VectorStore
 
 
 @cl.on_chat_start
@@ -29,6 +37,70 @@ async def on_chat_start():
         ).send()
         return
 
-    await cl.Message(
-        content="No documents indexed. Configure your documents folder in settings to get started."
-    ).send()
+    # Set up vector store with persistent ChromaDB and Ollama embeddings
+    embed_fn = make_ollama_embed_fn(model=config.models.embedding)
+    chroma_client = chromadb.PersistentClient(
+        path=str(config.paths.chroma_db),
+    )
+    store = VectorStore(embed_fn=embed_fn, client=chroma_client)
+    cl.user_session.set("store", store)
+
+    # Ingest documents if a folder is configured
+    doc_count = len(store.get_all_texts())
+    if config.paths.documents and Path(config.paths.documents).exists():
+        docs = load_folder(
+            Path(config.paths.documents),
+            recursive=config.scanning.recursive,
+        )
+        if docs:
+            chunks = chunk_documents(
+                docs,
+                chunk_size=config.chunking.chunk_size,
+                chunk_overlap=config.chunking.chunk_overlap,
+            )
+            store.add_chunks(chunks)
+            doc_count = len(store.get_all_texts())
+            await cl.Message(
+                content=f"Ingested {len(docs)} pages into {doc_count} chunks. Ask me anything!"
+            ).send()
+            return
+
+    if doc_count > 0:
+        await cl.Message(
+            content=f"{doc_count} chunks indexed. Ask me anything!"
+        ).send()
+    else:
+        await cl.Message(
+            content="No documents indexed. Configure your documents folder in `config.yaml` to get started."
+        ).send()
+
+
+@cl.on_message
+async def on_message(message: cl.Message):
+    config = cl.user_session.get("config")
+    store = cl.user_session.get("store")
+
+    if store is None:
+        await cl.Message(content="No document store available. Please restart the app.").send()
+        return
+
+    if len(store.get_all_texts()) == 0:
+        await cl.Message(
+            content="No documents indexed yet. Configure your documents folder in `config.yaml` first."
+        ).send()
+        return
+
+    results = store.search(
+        message.content,
+        k=config.retrieval.semantic_top_k,
+    )
+
+    # Stream the answer token by token
+    msg = cl.Message(content="")
+    async for token in answer(
+        message.content,
+        results,
+        model=config.models.llm,
+    ):
+        await msg.stream_token(token)
+    await msg.send()

--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import chainlit as cl
 import chromadb
 
@@ -47,9 +45,9 @@ async def on_chat_start():
 
     # Ingest documents if a folder is configured
     doc_count = len(store.get_all_texts())
-    if config.paths.documents and Path(config.paths.documents).exists():
+    if str(config.paths.documents) and config.paths.documents.exists():
         docs = load_folder(
-            Path(config.paths.documents),
+            config.paths.documents,
             recursive=config.scanning.recursive,
         )
         if docs:

--- a/src/config.py
+++ b/src/config.py
@@ -28,9 +28,9 @@ class RetrievalConfig(BaseModel):
 
 class PathsConfig(BaseModel):
     chroma_db: Path = Path("~/.multi_doc_query/chroma_db/")
-    documents: str = ""
+    documents: Path = Path("")
 
-    @field_validator("chroma_db", mode="before")
+    @field_validator("chroma_db", "documents", mode="before")
     @classmethod
     def expand_home(cls, v: str | Path) -> Path:
         return Path(v).expanduser()

--- a/src/generation/answerer.py
+++ b/src/generation/answerer.py
@@ -1,0 +1,57 @@
+from collections.abc import AsyncIterator
+
+import ollama
+
+from src.retrieval.vector_store import SearchResult
+
+# --- Not via LangChain: prompt construction and LLM calls use direct
+#     ollama.chat() for full control over streaming and prompt format. ---
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant that answers questions based on the provided "
+    "document excerpts. Follow these rules:\n"
+    "1. Base your answer only on the provided excerpts.\n"
+    "2. Cite sources inline using [filename, p. N] format.\n"
+    "3. If excerpts from different documents conflict, highlight the "
+    "discrepancy and cite both sources.\n"
+    "4. If no excerpts are relevant to the question, say so clearly."
+)
+
+
+def build_prompt(question: str, results: list[SearchResult]) -> list[dict]:
+    """Build chat messages for Ollama from a question and search results."""
+    context_parts = []
+    for r in results:
+        filename = r.metadata.get("filename", "unknown")
+        page = r.metadata.get("page_number", "?")
+        context_parts.append(
+            f"--- Source: {filename} | Page {page} ---\n{r.text}"
+        )
+
+    context = "\n\n".join(context_parts)
+
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Document excerpts:\n\n{context}\n\n"
+                f"Question: {question}"
+            ),
+        },
+    ]
+
+
+async def answer(
+    question: str,
+    results: list[SearchResult],
+    *,
+    model: str = "llama3.1:8b",
+) -> AsyncIterator[str]:
+    """Stream answer tokens from Ollama."""
+    messages = build_prompt(question, results)
+    stream = ollama.chat(model=model, messages=messages, stream=True)
+    for chunk in stream:
+        token = chunk["message"]["content"]
+        if token:
+            yield token

--- a/src/health_check.py
+++ b/src/health_check.py
@@ -39,7 +39,14 @@ async def check_models(
     async with httpx.AsyncClient(timeout=10.0) as client:
         response = await client.get(f"{base_url}/api/tags")
 
-    available = {model["name"] for model in response.json().get("models", [])}
+    available = set()
+    for model in response.json().get("models", []):
+        name = model["name"]
+        available.add(name)
+        # Also register without :latest so "mxbai-embed-large" matches
+        # "mxbai-embed-large:latest"
+        if name.endswith(":latest"):
+            available.add(name.removesuffix(":latest"))
 
     missing = [name for name in required if name not in available]
     if missing:

--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -1,0 +1,43 @@
+import hashlib
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+from src.models import Chunk, Document
+
+# --- LangChain boundary: RecursiveCharacterTextSplitter used for text splitting.
+#     All other pipeline stages (embeddings, vector store, LLM calls) use
+#     direct library calls, not LangChain. ---
+
+
+def chunk_documents(
+    documents: list[Document],
+    *,
+    chunk_size: int = 512,
+    chunk_overlap: int = 100,
+) -> list[Chunk]:
+    """Split documents into chunks with preserved and extended metadata."""
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+    )
+
+    chunks: list[Chunk] = []
+
+    for doc in documents:
+        doc_hash = hashlib.md5(doc.text.encode()).hexdigest()
+        splits = splitter.split_text(doc.text)
+
+        for i, text in enumerate(splits):
+            chunks.append(
+                Chunk(
+                    text=text,
+                    metadata={
+                        **doc.metadata,
+                        "chunk_index": i,
+                        "doc_hash": doc_hash,
+                    },
+                )
+            )
+
+    return chunks

--- a/src/ingestion/loader.py
+++ b/src/ingestion/loader.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from langchain_community.document_loaders import PyPDFLoader
+
+from src.models import Document
+
+# --- LangChain boundary: PyPDFLoader used for PDF parsing.
+#     This is one of two LangChain touch-points (the other is
+#     RecursiveCharacterTextSplitter in chunker.py). All other
+#     pipeline stages use direct library calls. ---
+
+
+def load_folder(path: Path, *, recursive: bool = True) -> list[Document]:
+    """Load all PDF files from a folder into Document objects."""
+    path = Path(path)
+
+    if recursive:
+        pdf_files = sorted(path.rglob("*.pdf"))
+    else:
+        pdf_files = sorted(path.glob("*.pdf"))
+
+    documents: list[Document] = []
+
+    for pdf_path in pdf_files:
+        loader = PyPDFLoader(str(pdf_path))
+        pages = loader.load()
+
+        for page in pages:
+            documents.append(
+                Document(
+                    text=page.page_content,
+                    metadata={
+                        "filename": pdf_path.name,
+                        "doc_type": "pdf",
+                        "page_number": page.metadata.get("page", 0) + 1,
+                    },
+                )
+            )
+
+    return documents

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Document:
+    text: str
+    metadata: dict[str, str | int]
+
+
+@dataclass
+class Chunk:
+    text: str
+    metadata: dict[str, str | int]
+
+
+@dataclass
+class SearchResult:
+    text: str
+    metadata: dict[str, str | int]
+    distance: float

--- a/src/retrieval/embeddings.py
+++ b/src/retrieval/embeddings.py
@@ -1,0 +1,18 @@
+from collections.abc import Callable
+
+import ollama
+
+# --- Not via LangChain: embeddings use direct ollama.embed() calls
+#     for full control and to avoid unnecessary framework coupling. ---
+
+EmbedFn = Callable[[list[str]], list[list[float]]]
+
+
+def make_ollama_embed_fn(model: str = "mxbai-embed-large") -> EmbedFn:
+    """Create an embedding function that calls ollama.embed()."""
+
+    def embed(texts: list[str]) -> list[list[float]]:
+        result = ollama.embed(model=model, input=texts)
+        return result["embeddings"]
+
+    return embed

--- a/src/retrieval/vector_store.py
+++ b/src/retrieval/vector_store.py
@@ -1,0 +1,80 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import chromadb
+
+from src.models import Chunk, SearchResult
+
+# Type alias for the embedding function dependency.
+# Not via LangChain — embeddings use direct ollama.embed() in production.
+EmbedFn = Callable[[list[str]], list[list[float]]]
+
+
+class VectorStore:
+    """ChromaDB-backed vector store with injected embedding function."""
+
+    def __init__(
+        self,
+        embed_fn: EmbedFn,
+        client: chromadb.ClientAPI | None = None,
+        collection_name: str = "documents",
+    ):
+        if client is None:
+            client = chromadb.Client()
+        self._client = client
+        self._embed_fn = embed_fn
+        self._collection = client.get_or_create_collection(
+            name=collection_name,
+            metadata={"hnsw:space": "cosine"},
+        )
+
+    def add_chunks(self, chunks: list[Chunk]) -> None:
+        """Embed and store chunks in ChromaDB."""
+        if not chunks:
+            return
+
+        texts = [c.text for c in chunks]
+        embeddings = self._embed_fn(texts)
+        metadatas = [c.metadata for c in chunks]
+        ids = [f"chunk_{i}" for i in range(
+            self._collection.count(),
+            self._collection.count() + len(chunks),
+        )]
+
+        self._collection.add(
+            documents=texts,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            ids=ids,
+        )
+
+    def search(self, query: str, k: int = 5) -> list[SearchResult]:
+        """Return the top-k most similar chunks for a query."""
+        query_embedding = self._embed_fn([query])[0]
+        results = self._collection.query(
+            query_embeddings=[query_embedding],
+            n_results=min(k, self._collection.count()),
+        )
+
+        search_results = []
+        for i in range(len(results["documents"][0])):
+            search_results.append(
+                SearchResult(
+                    text=results["documents"][0][i],
+                    metadata=results["metadatas"][0][i],
+                    distance=results["distances"][0][i],
+                )
+            )
+        return search_results
+
+    def get_all_texts(self) -> list[str]:
+        """Return all stored chunk texts."""
+        result = self._collection.get()
+        return result["documents"]
+
+    def has_document(self, doc_hash: str) -> bool:
+        """Check if any chunk with the given doc_hash exists."""
+        result = self._collection.get(
+            where={"doc_hash": doc_hash},
+        )
+        return len(result["ids"]) > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import hashlib
+
+import pytest
+
+from src.models import Chunk, Document
+
+
+def _fake_embed(texts: list[str]) -> list[list[float]]:
+    """Deterministic embedder: hash each text to a fixed-length vector."""
+    result = []
+    for t in texts:
+        h = hashlib.md5(t.encode()).hexdigest()
+        vec = [float(int(c, 16)) / 15.0 for c in h]
+        result.append((vec * 12)[:384])
+    return result
+
+
+@pytest.fixture
+def fake_embed_fn():
+    return _fake_embed
+
+
+@pytest.fixture
+def sample_document():
+    return Document(
+        text="This is a test document about artificial intelligence and machine learning.",
+        metadata={"filename": "test.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+
+
+@pytest.fixture
+def sample_chunks():
+    return [
+        Chunk(
+            text="Chunk about AI and neural networks",
+            metadata={
+                "filename": "test.pdf",
+                "doc_type": "pdf",
+                "page_number": 1,
+                "chunk_index": 0,
+                "doc_hash": "abc123",
+            },
+        ),
+        Chunk(
+            text="Chunk about cooking recipes and ingredients",
+            metadata={
+                "filename": "test.pdf",
+                "doc_type": "pdf",
+                "page_number": 2,
+                "chunk_index": 1,
+                "doc_hash": "abc123",
+            },
+        ),
+    ]

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,0 +1,53 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>
+endobj
+
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]
+   /Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 12 Tf 100 700 Td (Page one content.) Tj ET
+endstream
+endobj
+
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]
+   /Contents 6 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+
+6 0 obj
+<< /Length 44 >>
+stream
+BT /F1 12 Tf 100 700 Td (Page two content.) Tj ET
+endstream
+endobj
+
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000266 00000 n 
+0000000360 00000 n 
+0000000511 00000 n 
+0000000605 00000 n 
+
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+681
+%%EOF

--- a/tests/test_answerer.py
+++ b/tests/test_answerer.py
@@ -1,0 +1,40 @@
+from src.generation.answerer import build_prompt
+from src.retrieval.vector_store import SearchResult
+
+
+def _make_results():
+    return [
+        SearchResult(
+            text="Paris is the capital of France.",
+            metadata={"filename": "geo.pdf", "doc_type": "pdf", "page_number": 5},
+            distance=0.1,
+        ),
+        SearchResult(
+            text="Berlin is the capital of Germany.",
+            metadata={"filename": "europe.pdf", "doc_type": "pdf", "page_number": 12},
+            distance=0.2,
+        ),
+    ]
+
+
+def test_build_prompt_includes_context():
+    """The prompt includes the text from search results."""
+    messages = build_prompt("What is the capital of France?", _make_results())
+    content = " ".join(m["content"] for m in messages)
+    assert "Paris is the capital of France." in content
+    assert "Berlin is the capital of Germany." in content
+
+
+def test_build_prompt_includes_question():
+    """The prompt includes the user's question."""
+    messages = build_prompt("What is the capital of France?", _make_results())
+    content = " ".join(m["content"] for m in messages)
+    assert "What is the capital of France?" in content
+
+
+def test_build_prompt_source_format():
+    """Context is formatted with source citations: --- Source: filename | Page N ---"""
+    messages = build_prompt("question", _make_results())
+    content = " ".join(m["content"] for m in messages)
+    assert "--- Source: geo.pdf | Page 5 ---" in content
+    assert "--- Source: europe.pdf | Page 12 ---" in content

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,69 @@
+from src.ingestion.chunker import chunk_documents
+from src.models import Document
+
+
+def test_chunk_short_document_single_chunk():
+    """A document shorter than chunk_size returns exactly one chunk."""
+    doc = Document(
+        text="Short text.",
+        metadata={"filename": "test.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+    chunks = chunk_documents([doc], chunk_size=512, chunk_overlap=100)
+    assert len(chunks) == 1
+    assert chunks[0].text == "Short text."
+
+
+def test_chunk_long_document_multiple_chunks():
+    """A document longer than chunk_size returns multiple chunks."""
+    doc = Document(
+        text="word " * 200,  # 1000 chars, well over chunk_size=100
+        metadata={"filename": "test.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+    chunks = chunk_documents([doc], chunk_size=100, chunk_overlap=20)
+    assert len(chunks) > 1
+
+
+def test_chunk_size_within_limit():
+    """Each chunk's text length does not exceed chunk_size."""
+    doc = Document(
+        text="word " * 200,
+        metadata={"filename": "test.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+    chunks = chunk_documents([doc], chunk_size=100, chunk_overlap=20)
+    for chunk in chunks:
+        assert len(chunk.text) <= 100
+
+
+def test_chunk_preserves_source_metadata():
+    """Each chunk retains filename, doc_type, page_number from its source."""
+    doc = Document(
+        text="Some content here.",
+        metadata={"filename": "report.pdf", "doc_type": "pdf", "page_number": 3},
+    )
+    chunks = chunk_documents([doc], chunk_size=512, chunk_overlap=100)
+    assert chunks[0].metadata["filename"] == "report.pdf"
+    assert chunks[0].metadata["doc_type"] == "pdf"
+    assert chunks[0].metadata["page_number"] == 3
+
+
+def test_chunk_has_chunk_index():
+    """Chunks have sequential 0-based chunk_index."""
+    doc = Document(
+        text="word " * 200,
+        metadata={"filename": "test.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+    chunks = chunk_documents([doc], chunk_size=100, chunk_overlap=20)
+    for i, chunk in enumerate(chunks):
+        assert chunk.metadata["chunk_index"] == i
+
+
+def test_chunk_has_doc_hash():
+    """Each chunk has a doc_hash (MD5 of the source document text)."""
+    doc = Document(
+        text="Unique document content.",
+        metadata={"filename": "test.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+    chunks = chunk_documents([doc], chunk_size=512, chunk_overlap=100)
+    assert "doc_hash" in chunks[0].metadata
+    assert isinstance(chunks[0].metadata["doc_hash"], str)
+    assert len(chunks[0].metadata["doc_hash"]) == 32  # MD5 hex length

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,7 +37,7 @@ scanning:
     assert config.retrieval.bm25_top_k == 10
     assert config.retrieval.reranker_model == "test-reranker"
     assert config.paths.chroma_db == Path("/tmp/test_chroma")
-    assert config.paths.documents == "/tmp/docs"
+    assert config.paths.documents == Path("/tmp/docs")
     assert config.scanning.recursive is False
 
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -88,3 +88,18 @@ async def test_check_models_all_missing(mock_client_cls):
     assert result.ok is False
     assert "ollama pull llama3.1:8b" in result.message
     assert "ollama pull mxbai-embed-large" in result.message
+
+
+@patch("src.health_check.httpx.AsyncClient")
+async def test_check_models_matches_without_latest_tag(mock_client_cls):
+    """Requesting 'mxbai-embed-large' matches 'mxbai-embed-large:latest'."""
+    mock_client = AsyncMock()
+    mock_client.get.return_value = _mock_response(
+        200,
+        {"models": [{"name": "llama3.1:8b"}, {"name": "mxbai-embed-large:latest"}]},
+    )
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+    result = await check_models(["llama3.1:8b", "mxbai-embed-large"])
+
+    assert result.ok is True

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from src.ingestion.loader import load_folder
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_load_single_pdf_returns_documents():
+    """Loading a folder with one PDF returns a non-empty list of Documents."""
+    docs = load_folder(FIXTURES)
+    assert len(docs) > 0
+
+
+def test_document_has_text():
+    """Each Document has non-empty text."""
+    docs = load_folder(FIXTURES)
+    for doc in docs:
+        assert doc.text.strip()
+
+
+def test_document_metadata_filename():
+    """Each Document has the correct filename in metadata."""
+    docs = load_folder(FIXTURES)
+    filenames = {doc.metadata["filename"] for doc in docs}
+    assert "sample.pdf" in filenames
+
+
+def test_document_metadata_doc_type():
+    """Each Document has doc_type='pdf' in metadata."""
+    docs = load_folder(FIXTURES)
+    for doc in docs:
+        assert doc.metadata["doc_type"] == "pdf"
+
+
+def test_document_metadata_page_number():
+    """Each Document has a 1-indexed page_number in metadata."""
+    docs = load_folder(FIXTURES)
+    page_numbers = [doc.metadata["page_number"] for doc in docs]
+    assert 1 in page_numbers
+    assert all(isinstance(p, int) and p >= 1 for p in page_numbers)
+
+
+def test_load_folder_empty_dir(tmp_path):
+    """An empty folder returns an empty list."""
+    docs = load_folder(tmp_path)
+    assert docs == []
+
+
+def test_load_folder_recursive(tmp_path):
+    """With recursive=True, finds PDFs in subdirectories."""
+    import shutil
+
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    shutil.copy(FIXTURES / "sample.pdf", sub / "nested.pdf")
+
+    docs = load_folder(tmp_path, recursive=True)
+    filenames = {doc.metadata["filename"] for doc in docs}
+    assert "nested.pdf" in filenames
+
+
+def test_load_folder_non_recursive(tmp_path):
+    """With recursive=False, ignores PDFs in subdirectories."""
+    import shutil
+
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    shutil.copy(FIXTURES / "sample.pdf", sub / "nested.pdf")
+
+    docs = load_folder(tmp_path, recursive=False)
+    assert docs == []

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,27 @@
+from src.generation.answerer import build_prompt
+from src.ingestion.chunker import chunk_documents
+from src.models import Document
+from src.retrieval.vector_store import VectorStore
+
+
+def test_tracer_bullet_ingestion_to_prompt(fake_embed_fn):
+    """Thinnest end-to-end path: document → chunk → store → search → prompt."""
+    doc = Document(
+        text="The capital of France is Paris.",
+        metadata={"filename": "geo.pdf", "doc_type": "pdf", "page_number": 1},
+    )
+
+    chunks = chunk_documents([doc], chunk_size=9999, chunk_overlap=0)
+    assert len(chunks) == 1
+
+    store = VectorStore(embed_fn=fake_embed_fn)
+    store.add_chunks(chunks)
+
+    results = store.search("What is the capital of France?", k=1)
+    assert len(results) == 1
+    assert "Paris" in results[0].text
+
+    messages = build_prompt("What is the capital of France?", results)
+    prompt_text = " ".join(m["content"] for m in messages)
+    assert "Paris" in prompt_text
+    assert "capital of France" in prompt_text

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,71 @@
+import uuid
+
+from src.models import Chunk
+from src.retrieval.vector_store import VectorStore
+
+
+def _make_store(embed_fn):
+    """Create a VectorStore with a unique collection name for test isolation."""
+    return VectorStore(embed_fn=embed_fn, collection_name=f"test_{uuid.uuid4().hex}")
+
+
+def test_add_chunks_stores_in_collection(fake_embed_fn, sample_chunks):
+    """After add_chunks(), collection count matches the number of chunks."""
+    store = _make_store(fake_embed_fn)
+    store.add_chunks(sample_chunks)
+    assert len(store.get_all_texts()) == 2
+
+
+def test_get_all_texts_returns_stored_texts(fake_embed_fn, sample_chunks):
+    """get_all_texts() returns all chunk texts that were added."""
+    store = _make_store(fake_embed_fn)
+    store.add_chunks(sample_chunks)
+    texts = store.get_all_texts()
+    assert set(texts) == {c.text for c in sample_chunks}
+
+
+def test_has_document_true_after_add(fake_embed_fn, sample_chunks):
+    """has_document returns True for a doc_hash that was added."""
+    store = _make_store(fake_embed_fn)
+    store.add_chunks(sample_chunks)
+    assert store.has_document("abc123") is True
+
+
+def test_has_document_false_when_absent(fake_embed_fn):
+    """has_document returns False for an unknown doc_hash."""
+    store = _make_store(fake_embed_fn)
+    assert store.has_document("nonexistent") is False
+
+
+def test_search_returns_k_results(fake_embed_fn):
+    """search(query, k=2) returns exactly 2 results when store has >= 2 chunks."""
+    chunks = [
+        Chunk(text=f"Chunk number {i}", metadata={"filename": "t.pdf", "doc_type": "pdf", "page_number": 1, "chunk_index": i, "doc_hash": "h1"})
+        for i in range(5)
+    ]
+    store = _make_store(fake_embed_fn)
+    store.add_chunks(chunks)
+    results = store.search("query", k=2)
+    assert len(results) == 2
+
+
+def test_search_returns_fewer_when_store_small(fake_embed_fn):
+    """search(query, k=5) returns only 2 results when store has 2 chunks."""
+    chunks = [
+        Chunk(text=f"Chunk {i}", metadata={"filename": "t.pdf", "doc_type": "pdf", "page_number": 1, "chunk_index": i, "doc_hash": "h1"})
+        for i in range(2)
+    ]
+    store = _make_store(fake_embed_fn)
+    store.add_chunks(chunks)
+    results = store.search("query", k=5)
+    assert len(results) == 2
+
+
+def test_search_results_have_text_and_metadata(fake_embed_fn, sample_chunks):
+    """Each search result has text and metadata fields."""
+    store = _make_store(fake_embed_fn)
+    store.add_chunks(sample_chunks)
+    results = store.search("AI", k=1)
+    assert results[0].text
+    assert "filename" in results[0].metadata
+    assert "page_number" in results[0].metadata


### PR DESCRIPTION
## Summary

- Added `DocumentLoader`, `Chunker`, `VectorStore`, and `Answerer` modules implementing the first end-to-end RAG slice
- Wired Chainlit `on_message` handler: query → semantic search → streamed LLM answer
- LangChain used only for PDF loading (PyPDFLoader) and text splitting (RecursiveCharacterTextSplitter), with boundary comments throughout
- All other components (embeddings, vector store, prompt construction, LLM calls) use direct library calls (ollama, chromadb)

Closes #4

## Test plan

- [x] Tracer bullet test: Document → chunk → store → search → prompt (end-to-end path)
- [x] Chunker tests: short/long docs, size limits, metadata preservation, chunk_index, doc_hash
- [x] DocumentLoader tests: PDF loading, metadata, empty folder, recursive/non-recursive
- [x] VectorStore tests: add, search, get_all_texts, has_document (in-memory ChromaDB)
- [x] Answerer tests: prompt construction with source citations
- [x] Manual: `uv run chainlit run app.py` with a configured document folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)