### PR TITLE
Fixed reranker model name

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,7 @@ class RetrievalConfig(BaseModel):
     semantic_top_k: int = 20
     rrf_k: int = 60
     rerank_top_k: int = 10
-    reranker_model: str = "bge-reranker-v2-m3"
+    reranker_model: str = "BAAI/bge-reranker-v2-m3"
 
 
 class PathsConfig(BaseModel):


### PR DESCRIPTION
## Summary
- Fixed default `reranker_model` from `bge-reranker-v2-m3` to `BAAI/bge-reranker-v2-m3` — HuggingFace requires the org prefix to resolve the repo

## Test plan
- [x] App starts without OSError on reranker init
- [x] 99 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)